### PR TITLE
limit_mv and module

### DIFF
--- a/include/iRRAM/limit_templates.h
+++ b/include/iRRAM/limit_templates.h
@@ -377,7 +377,23 @@ limit_mv(R (*seq)(int prec, C &choice, const Args &... args),
 					        4 +
 					        iRRAM_prec_array[element_step];
 					firsttime = 1;
-				}
+				}		
+			if (firsttime != 0 || sizetype_less(limnew_error, lim_error)) {
+			lim = limnew;
+			lim_error = limnew_error;
+			iRRAM_DEBUG2(2, "getting result with error %d*2^(%d)\n",
+			             lim_error.mantissa, lim_error.exponent);
+			} else {
+				iRRAM_DEBUG1(
+				        2,
+				        "computation successful, but no improvement\n");
+			}
+			firsttime = 0;
+			if (element <= env.saved_prec())
+				break;
+			element_step += 4;
+			element = iRRAM_prec_array[element_step];
+
 		} catch (const Iteration &it) {
 			if (firsttime == 0) {
 				iRRAM_DEBUG1(2, "computation failed, using "
@@ -395,21 +411,6 @@ limit_mv(R (*seq)(int prec, C &choice, const Args &... args),
 				iRRAM_REITERATE(0);
 			}
 		}
-		if (firsttime != 0 || sizetype_less(limnew_error, lim_error)) {
-			lim = limnew;
-			lim_error = limnew_error;
-			iRRAM_DEBUG2(2, "getting result with error %d*2^(%d)\n",
-			             lim_error.mantissa, lim_error.exponent);
-		} else {
-			iRRAM_DEBUG1(
-			        2,
-			        "computation successful, but no improvement\n");
-		}
-		firsttime = 0;
-		if (element <= env.saved_prec())
-			break;
-		element_step += 4;
-		element = iRRAM_prec_array[element_step];
 	}
 	lim.seterror(lim_error);
 	iRRAM_DEBUG2(2, "end of gen limit_mv with error %d*2^(%d)\n",

--- a/src/REALS.cc
+++ b/src/REALS.cc
@@ -1284,7 +1284,7 @@ int iRRAM::module(REAL (*f)(const REAL&),const REAL& x, int p){
 	p_arg+=direction;
       break;
       case 1:;
-        if ( fail ) { try_it=false; p_arg -=direction; }
+        if ( fail || p_arg > 0 ) { try_it=false; p_arg -=direction; }
 	else { p_arg += direction; };
       break;
       case -1:;


### PR DESCRIPTION
The part where you indicate the success of the execution of the sequence function in `limit_mv` had been moved below the `catch` block:

```
try: execute the sequence function
catch: decrease the index of the sequence or something
set up indicators for success
```

where it's supposed to be and fixed to be as follows:

```
try: execute the sequence function and set up indicators for success
catch: decrease the index of the sequence or something
``` 

The function `module` used to run into an infinite loop when a constant function is given.